### PR TITLE
feat: add seed subject script, minor changes in subjects migration and schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@ kosh-*.tar
 /priv/static/assets/
 /priv/static/cache_manifest.json
 /priv/static/uploads
+/priv/static/subjects_seed/
 npm-debug.log
 /assets/node_modules/
 env.*
-.docker/*
+.docker/*   

--- a/lib/kosh/ead/ead/subject.ex
+++ b/lib/kosh/ead/ead/subject.ex
@@ -5,6 +5,7 @@ defmodule Kosh.EAD.Subject do
   schema "subjects" do
     field :content, :string
     field :source, :string
+    field :unitid, :string, default: nil
 
     many_to_many :files, Kosh.EAD.File,
       join_through: "files_subjects",
@@ -27,8 +28,8 @@ defmodule Kosh.EAD.Subject do
   @doc false
   def changeset(subject, attrs) do
     subject
-    |> cast(attrs, [:content, :source])
+    |> cast(attrs, [:content, :source, :unitid])
     |> validate_required([:content, :source])
-    |> unique_constraint(:content, name: :subjects_content_source_index)
+    |> unique_constraint(:content, name: :subjects_content_index)
   end
 end

--- a/priv/repo/migrations/20250516111103_create_subjects.exs
+++ b/priv/repo/migrations/20250516111103_create_subjects.exs
@@ -4,11 +4,12 @@ defmodule Kosh.Repo.Migrations.CreateSubjects do
   def change do
     create table(:subjects) do
       add :content, :string, null: false
-      add :source,  :string, null: false
+      add :source, :string, null: false
+      add :unitid, :string, null: true
 
       timestamps()
     end
 
-    create unique_index(:subjects, [:content, :source], name: :subjects_content_source_index)
+    create unique_index(:subjects, [:content], name: :subjects_content_index)
   end
 end

--- a/priv/repo/seed_subjects.exs
+++ b/priv/repo/seed_subjects.exs
@@ -1,0 +1,85 @@
+alias Kosh.Repo
+alias Kosh.EAD.Subject
+require Logger
+
+defmodule Loader do
+  @moduledoc """
+  Stream the newline‐delimited JSON‐LD file and insert subjects in batches.
+  """
+
+  @filename "priv/static/subjects_seed/subjects.madsrdf.jsonld"
+  @batch_size 1_000
+
+  def run do
+
+    timestamp =
+      NaiveDateTime.utc_now()
+      |> NaiveDateTime.truncate(:second)
+
+    File.stream!(@filename, [], :line)
+    |> Stream.map(&String.trim/1)
+    |> Stream.reject(&(&1 == ""))                     # skip any blank lines
+    |> Stream.map(&safe_parse_subject_line/1)
+    |> Stream.reject(&is_nil/1)                        # drop any lines we couldn’t parse
+    |> Stream.map(fn base_map ->
+
+      Map.merge(base_map, %{
+        inserted_at: timestamp,
+        updated_at: timestamp
+      })
+    end)
+    |> Stream.chunk_every(@batch_size)
+    |> Stream.each(fn batch ->
+      Repo.insert_all(Subject, batch, on_conflict: :nothing, conflict_target: :content)
+      Logger.info("Inserted batch of #{length(batch)} subjects")
+    end)
+    |> Stream.run()
+
+    Logger.info("Finished inserting all subjects.")
+  end
+
+  defp safe_parse_subject_line(line) do
+    case Jason.decode(line) do
+      {:ok, %{"@graph" => graph}} ->
+        extract_from_graph(graph)
+
+      {:ok, _other} ->
+        # “@graph” key wasn’t present → skip
+        nil
+
+      {:error, _reason} ->
+        # Malformed JSON → skip
+        nil
+    end
+  end
+
+  defp extract_from_graph(graph) do
+    authority_node =
+      Enum.find(graph, fn
+        %{"@type" => types} when is_list(types) ->
+          Enum.any?(types, &(&1 == "madsrdf:Authority"))
+        _ ->
+          false
+      end) || hd(graph)
+
+    case authority_node["madsrdf:authoritativeLabel"] do
+      %{"@value" => title} when is_binary(title) ->
+        subject_id = authority_node["@id"] || ""
+        if subject_id == "" or title == "" do
+          nil
+        else
+          %{
+            unitid: subject_id,
+            content: title,
+            source: "loc"
+          }
+        end
+
+      _ ->
+        # No authoritativeLabel or unexpected structure → skip
+        nil
+    end
+  end
+end
+
+Loader.run()


### PR DESCRIPTION
- Added a new subject seed script.
- The data JSON file is kept in a folder "subjects_seed", and this folder has been added to the gitignore file. This is because the data file is very large (around 1.5 GB) and cannot be pushed.
- That file is needed for the seed script to work. 