### PR TITLE
feat: add checks for submitting and approving annotations

### DIFF
--- a/lib/kosh_web/live/annotations_index_live.ex
+++ b/lib/kosh_web/live/annotations_index_live.ex
@@ -40,7 +40,7 @@ defmodule KoshWeb.AnnotationsIndexLive do
   #   end
   # end
   def handle_event("approve_description", %{"id" => id}, socket) do
-    case Annotations.approve_description_annotation(id) do
+    case Annotations.approve_description_annotation(id, socket.assigns.current_user.id) do
       {:ok, _} ->
         socket =
           socket
@@ -92,7 +92,7 @@ defmodule KoshWeb.AnnotationsIndexLive do
   end
 
   def handle_event("approve_subject_annotation", %{"id" => id}, socket) do
-    case Annotations.approve_subject_annotation(id) do
+    case Annotations.approve_subject_annotation(id, socket.assigns.current_user.id) do
       {:ok, _} ->
         socket =
           socket
@@ -103,6 +103,15 @@ defmodule KoshWeb.AnnotationsIndexLive do
 
       {:error, :not_found} ->
         socket = socket |> put_flash(:error, "Subject annotation not found")
+        {:noreply, socket}
+
+      {:error, :all_subjects_already_present} ->
+        socket =
+          socket
+          |> put_flash(
+            :error,
+            "All the subjects in this annotations are already present in the file"
+          )
         {:noreply, socket}
 
       {:error, changeset} ->


### PR DESCRIPTION
This PR adds new checks for submitting and approving annotations:

Changes:
- Add admin_id when an admin approves the annotation. 
- Added a check when a user creates a new annotation. If any of the subjects is already present in the file, the form would not get submitted with the appropriate error like "The 'some subject' already exists." 
- On approving the annotation, added a check to go through all the subjects in the given subject annotation and check if any subject already exists in the file's subjects or the file's approved-annotated-subjects. 
  - If no new subject is there, we don't approve the annotation and display an appropriate error like "All the subjects already exist for the file". 
  - If there is any new subject (along with the subjects that are already present), we normally approve the annotation, but we only add the new subject as an annotation to the file. We also update the annotation to keep only the new subjects and remove all the existing subjects (this updated annotation with updated content will be visible in the "Submitted Annotations" section). 
  - This also takes care of this kind of scenario: If user-A creates an annotation with some subject-1, and before that annotation gets approved, user-B also creates a new annotation with the same subject-1 (as user-A's annotation is not approved yet, user-B can submit new annotations with subject-1). Now, if an admin approves user-B's annotation first, and then moves on to approve user-A's annotation, we won't see subject-1 getting repeated in the file's approved annotations. If user-A's annotation had some other new subjects, other than subject-1, only they will be added to the file's approved annotations.  

CC: @dennyabrain 