### PR TITLE
fix: add uri column to file, replace sql join with Ecto schemas

### DIFF
--- a/lib/kosh/ead/ead/collection.ex
+++ b/lib/kosh/ead/ead/collection.ex
@@ -10,7 +10,7 @@ defmodule Kosh.EAD.Collection do
     field :upload_path, :string
 
     many_to_many :subjects, Kosh.EAD.Subject,
-      join_through: "collections_subjects",
+      join_through: Kosh.EAD.CollectionsSubject,
       on_delete: :nothing,
       on_replace: :delete
 

--- a/lib/kosh/ead/ead/collections_subject.ex
+++ b/lib/kosh/ead/ead/collections_subject.ex
@@ -1,0 +1,18 @@
+defmodule Kosh.EAD.CollectionsSubject do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  schema "collections_subjects" do
+    belongs_to :collection, Kosh.EAD.Collection, primary_key: true
+    belongs_to :subject, Kosh.EAD.Subject, primary_key: true
+
+    timestamps()
+  end
+
+  def changeset(collections_subject, attrs) do
+    collections_subject
+    |> cast(attrs, [:collection_id, :subject_id])
+    |> validate_required([:collection_id, :subject_id])
+  end
+end

--- a/lib/kosh/ead/ead/file.ex
+++ b/lib/kosh/ead/ead/file.ex
@@ -7,6 +7,7 @@ defmodule Kosh.EAD.File do
   schema "files" do
     field :title, :string
     field :description, {:array, :string}, default: []
+    field :uri, :string
 
     # all possible fields: address, arrangement, blockquote, chronlist, dao, daogrp, head, list, note, p, scopecontent, table
     # field :scopecontent, :map,
@@ -24,7 +25,7 @@ defmodule Kosh.EAD.File do
     belongs_to :sub_series, Kosh.EAD.SubSeries
 
     many_to_many :subjects, Kosh.EAD.Subject,
-      join_through: "files_subjects",
+      join_through: Kosh.EAD.FilesSubject,
       on_delete: :nothing,
       on_replace: :delete
 
@@ -58,13 +59,14 @@ defmodule Kosh.EAD.File do
       :description,
       :collection_id,
       :series_id,
-      :sub_series_id
+      :sub_series_id,
+      :uri
     ])
     |> cast_embed(:unitdate)
     |> cast_embed(:unitid)
     |> cast_embed(:dao)
     |> cast_assoc(:subjects, with: &Kosh.EAD.Subject.changeset/2)
-    |> validate_required([:title, :collection_id])
+    |> validate_required([:title, :collection_id, :uri])
     |> then(fn cs ->
       Ecto.Changeset.validate_change(cs, :sub_series_id, fn :sub_series_id, ss_id ->
         if ss_id && is_nil(get_field(cs, :series_id)) do

--- a/lib/kosh/ead/ead/files_subject.ex
+++ b/lib/kosh/ead/ead/files_subject.ex
@@ -1,0 +1,18 @@
+defmodule Kosh.EAD.FilesSubject do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  schema "files_subjects" do
+    belongs_to :file, Kosh.EAD.File, primary_key: true
+    belongs_to :subject, Kosh.EAD.Subject, primary_key: true
+
+    timestamps()
+  end
+
+  def changeset(files_subject, attrs) do
+    files_subject
+    |> cast(attrs, [:file_id, :subject_id])
+    |> validate_required([:file_id, :subject_id])
+  end
+end

--- a/lib/kosh/ead/ead/subject.ex
+++ b/lib/kosh/ead/ead/subject.ex
@@ -8,12 +8,12 @@ defmodule Kosh.EAD.Subject do
     field :unitid, :string, default: nil
 
     many_to_many :files, Kosh.EAD.File,
-      join_through: "files_subjects",
+      join_through: Kosh.EAD.FilesSubject,
       on_delete: :nothing,
       on_replace: :delete
 
     many_to_many :collections, Kosh.EAD.Collection,
-      join_through: "collections_subjects",
+      join_through: Kosh.EAD.CollectionsSubject,
       on_delete: :nothing,
       on_replace: :delete
 

--- a/lib/kosh_web/live/upload_live.ex
+++ b/lib/kosh_web/live/upload_live.ex
@@ -72,6 +72,7 @@ defmodule KoshWeb.UploadLive do
                }}
 
             {:error, reason} ->
+              IO.inspect(reason)
               {:ok, %{path: nil, processed: false, error: format_error(reason)}}
           end
         end

--- a/priv/repo/migrations/20250516111101_create_files.exs
+++ b/priv/repo/migrations/20250516111101_create_files.exs
@@ -4,6 +4,7 @@ defmodule Kosh.Repo.Migrations.CreateFiles do
   def change do
     create table(:files) do
       add :title, :text, null: false
+      add :uri, :string, null: false
       add :description, {:array, :text}, default: [], null: false
       add :unitdate, :map, default: %{}, null: false
       add :unitid, :map, default: %{}, null: false

--- a/priv/repo/migrations/20250516111101_create_files.exs
+++ b/priv/repo/migrations/20250516111101_create_files.exs
@@ -18,7 +18,8 @@ defmodule Kosh.Repo.Migrations.CreateFiles do
     end
 
     create index(:files, [:collection_id])
-    create index(:files, [:series_id])
-    create index(:files, [:sub_series_id])
+    create index(:files, [:uri])
+    # create index(:files, [:series_id])
+    # create index(:files, [:sub_series_id])
   end
 end

--- a/priv/repo/migrations/20250516111105_create_files_subjects_join.exs
+++ b/priv/repo/migrations/20250516111105_create_files_subjects_join.exs
@@ -6,6 +6,8 @@ defmodule Kosh.Repo.Migrations.CreateFilesSubjectsJoin do
     create table(:files_subjects, primary_key: false) do
       add :file_id,    references(:files,    on_delete: :delete_all), null: false
       add :subject_id, references(:subjects, on_delete: :nothing),    null: false
+
+      timestamps()
     end
 
     create unique_index(:files_subjects, [:file_id, :subject_id], name: :files_subjects_unique_index)


### PR DESCRIPTION
This PR implements the following changes:
- Add new "uri" column to the files table 
- Create and use Ecto schemas for joins (collection-subjects and files-subjects) 