### PR TITLE
feat: add new uri based routing for files

### DIFF
--- a/lib/kosh/ead.ex
+++ b/lib/kosh/ead.ex
@@ -171,6 +171,20 @@ defmodule Kosh.EAD do
     |> Repo.get(id)
   end
 
+  def get_file_from_uri(uri) do
+    File
+    |> preload([
+      :subjects,
+      :collection,
+      :series,
+      :sub_series,
+      :accepted_description_annotations,
+      accepted_subjects_annotations: :subjects
+    ])
+    |> Repo.get_by([uri: uri])
+
+  end
+
   @spec list_files() :: [struct()]
   def list_files do
     File

--- a/lib/kosh_web/live/display_index_live.ex
+++ b/lib/kosh_web/live/display_index_live.ex
@@ -73,7 +73,7 @@ defmodule KoshWeb.DisplayIndexLive do
                       </td>
                       <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                         <.link
-                          navigate={~p"/display/#{file.id}"}
+                          navigate={~p"/annotation/display/#{file.uri}"}
                           class="text-primary-purple hover:text-indigo-900"
                         >
                           View

--- a/lib/kosh_web/live/display_live.ex
+++ b/lib/kosh_web/live/display_live.ex
@@ -3,9 +3,17 @@ defmodule KoshWeb.DisplayLive do
   alias Kosh.EAD
 
   @impl Phoenix.LiveView
-  def mount(%{"id" => id}, _session, socket) do
+  def mount(%{"uri" => uri}, _session, socket) do
+    {:ok, socket |> redirect(to: "/annotation/display#{URI.decode(uri)}")}
+  end
+
+  @impl Phoenix.LiveView
+  def mount(%{"repository_id" => repository_id, "object_id" => object_id}, _session, socket) do
     # IO.inspect(socket, label: "id")
-    case EAD.get_file(id) do
+
+    uri = "/repositories/#{repository_id}/archival_objects/#{object_id}"
+
+    case EAD.get_file_from_uri(URI.decode(uri)) do
       nil ->
         {:ok,
          socket
@@ -33,10 +41,46 @@ defmodule KoshWeb.DisplayLive do
           else
             nil
           end
+
         # IO.inspect(file, label: "Display File")
         {:ok, assign(socket, file: file, manifest_url: manifest_url)}
     end
   end
+
+  # def mount(%{"uri" => uri}, _session, socket) do
+  #   # IO.inspect(socket, label: "id")
+  #   case EAD.get_file_from_uri( URI.decode(uri)) do
+  #     nil ->
+  #       {:ok,
+  #        socket
+  #        |> put_flash(:error, "File not found")
+  #        |> redirect(to: ~p"/upload")}
+
+  #     file ->
+  #       handle_url =
+  #         if file.dao && file.dao.daolocs do
+  #           case Enum.find(file.dao.daolocs, &String.contains?(&1["xlink_href"], "/handle/")) do
+  #             nil -> nil
+  #             loc -> Map.get(loc, "xlink_href")
+  #           end
+  #         else
+  #           nil
+  #         end
+
+  #       item_uuid = if handle_url, do: fetch_item_uuid(handle_url), else: nil
+
+  #       manifest_url =
+  #         if item_uuid do
+  #           URI.encode(
+  #             "https://collections.archives.ncbs.res.in/server/iiif/#{item_uuid}/manifest"
+  #           )
+  #         else
+  #           nil
+  #         end
+  #       # IO.inspect(file, label: "Display File")
+  #       {:ok, assign(socket, file: file, manifest_url: manifest_url)}
+  #   end
+  # end
 
   defp fetch_item_uuid(handle_url) do
     case HTTPoison.get(handle_url, [], follow_redirect: false) do

--- a/lib/kosh_web/live/upload_live.ex
+++ b/lib/kosh_web/live/upload_live.ex
@@ -47,7 +47,7 @@ defmodule KoshWeb.UploadLive do
              error: "A file with the name '#{entry.client_name}' already exists"
            }}
         else
-          # First try to process the file from its temporary location
+          ensure_uploads_dir()
           case EAD.process_xml_file(temp_path, dest_full) do
             # {:ok, collection} ->
             #   # Only if processing is successful, save to uploads directory

--- a/lib/kosh_web/router.ex
+++ b/lib/kosh_web/router.ex
@@ -140,11 +140,22 @@ defmodule KoshWeb.Router do
       live "/users/settings/confirm_email/:token", UserSettingsLive, :confirm_email
       # live "/testadmin", TestAdminRoleLive, :index
       # live "/gentoken", TokenGeneratorLive, :index
-      live "/upload", UploadLive, :index
-      live "/display", DisplayIndexLive, :index
-      live "/display/:id", DisplayLive, :show
-      live "/export-ead", ExportEADLive, :index
+
       # live "/annotations", AnnotationsIndexLive, :index
+    end
+  end
+
+  scope "/annotation", KoshWeb do
+    pipe_through [:browser, :require_authenticated_user]
+
+    live_session :annotation_files_authenticated,
+      on_mount: [
+        {KoshWeb.UserAuth, :ensure_authenticated},
+        {KoshWeb.UserAuth, :ensure_authorized}
+      ] do
+      live "/display-files", DisplayIndexLive, :index
+      live "/display/:uri", DisplayLive, :show
+      live "/display/repositories/:repository_id/archival_objects/:object_id", DisplayLive, :show
     end
   end
 
@@ -156,7 +167,9 @@ defmodule KoshWeb.Router do
         {KoshWeb.UserAuth, :ensure_authenticated},
         {KoshWeb.UserAuth, :ensure_authorized}
       ] do
-      live "/annotations", AnnotationsIndexLive, :index
+      live "/all-annotations", AnnotationsIndexLive, :index
+      live "/export-ead", ExportEADLive, :index
+      live "/upload", UploadLive, :index
     end
   end
 


### PR DESCRIPTION
This PR adds new routing for the files based on their URI. 
The new route looks like this: `/annotation/display/:uri` 
Example URL: 
"/annotation/display/repositories/2/archival_objects/9728"

We decode the encoded URL in case it is encoded (instead of "/" there is "%2F"), and then we parse this pattern:
/repositories/`repo_id`/archival_object/`object_id`. 
On retrieving the repo_id and object_id, we generate the URI and search for it in the database, and then display the file.