### PR TITLE
chore: add more details to annotation cards and create display file annotation route

### DIFF
--- a/lib/kosh/ead.ex
+++ b/lib/kosh/ead.ex
@@ -178,8 +178,8 @@ defmodule Kosh.EAD do
       :collection,
       :series,
       :sub_series,
-      accepted_description_annotations: [:file],
-      accepted_subjects_annotations: [:subjects, :file]
+      accepted_description_annotations: [:file, :user],
+      accepted_subjects_annotations: [:subjects, :file, :user]
     ])
     |> Repo.get_by([uri: uri])
 

--- a/lib/kosh_web/components/annotation_section/annotation_section_wrapper.ex
+++ b/lib/kosh_web/components/annotation_section/annotation_section_wrapper.ex
@@ -19,7 +19,10 @@ defmodule KoshWeb.Components.AnnotationSection.AnnotationSectionWrapper do
         []
       end
 
-    total_annotations = Annotations.count_total_approved_annotations()
+    # total_annotations = Annotations.count_total_approved_annotations()
+    total_annotations =
+      length(socket.assigns.file.accepted_description_annotations) +
+        length(socket.assigns.file.accepted_subjects_annotations)
 
     socket =
       assign(socket,

--- a/lib/kosh_web/components/annotation_section/annotation_section_wrapper.html.heex
+++ b/lib/kosh_web/components/annotation_section/annotation_section_wrapper.html.heex
@@ -77,9 +77,9 @@
         <div class="space-y-2 2xl:text-body-md-18">
           <p >
             We have collected <br />
-            <span class="font-bold"><%= @total_annotations %></span> user annotations
+            <span class="font-bold"><%= @total_annotations %></span> user annotations for this file
           </p>
-          <.link navigate="/annotation/all-annotations" class="flex items-center">
+          <.link navigate={"/annotation/file-annotations?uri=#{@file.uri}"} class="flex items-center">
             <span class=" underline font-semibold">View all</span>
             <img src="/images/redirect-black.svg" alt="icon" />
           </.link>

--- a/lib/kosh_web/components/description_annotation_card.ex
+++ b/lib/kosh_web/components/description_annotation_card.ex
@@ -76,8 +76,17 @@ defmodule KoshWeb.Components.DescriptionAnnotationCard do
           <%= @annotation.description %>
         </div>
         <%= if !@is_featured? do %>
-          <div class="text-caption-14 text-primary-grey">
-            <%= @annotation.file && @annotation.file.title %>
+          <div class="text-caption-14 text-primary-grey hover:text-secondary-grey">
+            <%= if @annotation.file && @annotation.file.title do %>
+              <.link navigate={"/annotation/display?uri=#{@annotation.file.uri}"}>
+                <%= @annotation.file.title %>
+              </.link>
+              <%= if @annotation.file.unitid && @annotation.file.unitid.id do %>
+                <span class="text-gray-500">
+                  - <%= @annotation.file.unitid.id %>
+                </span>
+              <% end %>
+            <% end %>
           </div>
         <% end %>
       </div>
@@ -90,7 +99,12 @@ defmodule KoshWeb.Components.DescriptionAnnotationCard do
             |> Timex.format!("{D} {Mfull} {YYYY}") %>
           </span>
         </div>
-        <div class="bg-bg-grey px-3 py-2 rounded-br-[4px]">
+        <%= if !!@annotation.user do %>
+          <div class="text-meta-12 ml-auto mx-2 max-w-36 truncate">
+            <%= @annotation.user.email %>
+          </div>
+        <% end %>
+        <div class="bg-bg-grey h-full flex items-center px-3 py-2 rounded-br-[4px]">
           <span class="uppercase text-meta-12 text-primary-grey">
             <%!-- <%= @annotation.file && @annotation.file.unitid && @annotation.file.unitid.id %> --%>
             <%= @annotation.id %>

--- a/lib/kosh_web/components/subject_annotation_card.ex
+++ b/lib/kosh_web/components/subject_annotation_card.ex
@@ -62,13 +62,28 @@ defmodule KoshWeb.Components.SubjectAnnotationCard do
                 <li class="py-3 border-b border-white last:border-b-0">
                   <%!-- <%= subject.content %> --%>
                   <%= if @annotation.status == :pending do %>
-                    <%= subject.content %>
+                    <span><%= subject.content %></span>
+                    <span class="text-primary-grey text-sm">
+                      <%= if subject.source do
+                        "- #{subject.source}"
+                      end %>
+                    </span>
                   <% end %>
                   <%= if @annotation.status == :accepted do %>
                     <%= if Enum.member?(@annotation.new_subjects || [], subject.content) do %>
-                      <%= subject.content %><span class="text-primary-grey"> (new)</span>
+                      <%= subject.content %><span class="text-primary-grey text-sm"> (new)</span>
+                      <span class="text-primary-grey text-sm">
+                        <%= if subject.source do
+                          "- #{subject.source}"
+                        end %>
+                      </span>
                     <% else %>
-                      <%= subject.content %>
+                      <span><%= subject.content %></span>
+                      <span class="text-primary-grey text-sm">
+                        <%= if subject.source do
+                          "- #{subject.source}"
+                        end %>
+                      </span>
                     <% end %>
                   <% end %>
                 </li>
@@ -77,15 +92,28 @@ defmodule KoshWeb.Components.SubjectAnnotationCard do
             <%= if Map.has_key?(@annotation, :new_subjects) && @annotation.new_subjects && length(@annotation.new_subjects) > 0 && @annotation.status == :pending do %>
               <%= for subject <- @annotation.new_subjects do %>
                 <li>
-                  <%= subject %> <span class="text-primary-grey">(new)</span>
+                  <%= subject %> <span class="text-primary-grey text-sm">(new)</span><span class="text-primary-grey text-sm">
+                        <%= if subject.source do
+                          "- #{subject.source}"
+                        end %>
+                      </span>
                 </li>
               <% end %>
             <% end %>
           </ul>
         </div>
         <%= if !@is_featured? do %>
-          <div class="text-caption-14 text-primary-grey">
-            <%= @annotation.file && @annotation.file.title %>
+          <div class="text-caption-14 text-primary-grey hover:text-secondary-grey">
+            <%= if @annotation.file && @annotation.file.title do %>
+              <.link navigate={"/annotation/display?uri=#{@annotation.file.uri}"}>
+                <%= @annotation.file.title %>
+              </.link>
+              <%= if @annotation.file.unitid && @annotation.file.unitid.id do %>
+                <span class="text-gray-500">
+                  - <%= @annotation.file.unitid.id %>
+                </span>
+              <% end %>
+            <% end %>
           </div>
         <% end %>
       </div>
@@ -98,6 +126,11 @@ defmodule KoshWeb.Components.SubjectAnnotationCard do
             |> Timex.format!("{D} {Mfull} {YYYY}") %>
           </span>
         </div>
+        <%= if !!@annotation.user do %>
+          <div class="text-meta-12 ml-auto mx-2 max-w-36 truncate">
+            <%= @annotation.user.email %>
+          </div>
+        <% end %>
         <div class="bg-bg-grey px-3 py-2 rounded-br-[4px]">
           <span class="uppercase text-meta-12 text-primary-grey">
             <%!-- <%= @annotation.file && @annotation.file.unitid && @annotation.file.unitid.id %> --%>

--- a/lib/kosh_web/live/home_live.ex
+++ b/lib/kosh_web/live/home_live.ex
@@ -25,14 +25,22 @@ defmodule KoshWeb.HomeLive do
                 Milli’s Annotation Tool allows users to search through and contribute annotations in the archive’s digital repository. It simplifies locating specific comments, notes, or metadata attached to materials like documents and images. By offering quick access to insights and cross-references, it’s a valuable resource for researchers and historians.
               </p>
             </div>
+            <p>
+            <.link
+                navigate={~p"/annotation/all-annotations"}
+                class="text-secondary-purple font-semibold xl:mt-10 mt-8 text-body-md-18 xl:text-body-lg-24 hover:underline "
+              >
+                View All Collected Annotations
+              </.link>
+              </p>
 
             <%= if @current_user do %>
-              <.link
+              <%!-- <.link
                 navigate={~p"/annotation/my-annotations"}
                 class="text-secondary-purple font-semibold xl:mt-10 mt-8 text-body-md-18 xl:text-body-lg-24 hover:underline "
               >
                 View My Annotations
-              </.link>
+              </.link> --%>
             <% else %>
               <p class="text-secondary-purple font-semibold xl:mt-10 mt-8 text-body-md-18 xl:text-body-lg-24">
                 Are you a new user? <.link navigate={~p"/users/register"} class="underline">Register to Annotate</.link>. If not,

--- a/lib/kosh_web/live/public_display_file_annotations_live.ex
+++ b/lib/kosh_web/live/public_display_file_annotations_live.ex
@@ -1,0 +1,58 @@
+defmodule KoshWeb.PublicDisplayFileAnnotationsLive do
+  alias Kosh.EAD
+  use KoshWeb, :live_view
+  import KoshWeb.Components.DescriptionAnnotationCard
+  import KoshWeb.Components.SubjectAnnotationCard
+
+  # def mount(_params, _session, socket) do
+  #   {subjects, descriptions} = Annotations.list_all_annotations(:accepted)
+  #   socket = assign(socket, approved_descriptions: descriptions, approved_subjects: subjects)
+  #   {:ok, socket}
+  # end
+  def mount(%{"uri" => uri}, _session, socket) do
+    # IO.inspect(socket, label: "id")
+    case EAD.get_file_from_uri(URI.decode(uri)) do
+      nil ->
+        {:ok,
+         socket
+         |> put_flash(:error, "File not found")
+         |> redirect(to: ~p"/")}
+
+      file ->
+        {:ok,
+         assign(socket,
+           file: file,
+           approved_descriptions: file.accepted_description_annotations,
+           approved_subjects: file.accepted_subjects_annotations
+         )}
+    end
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div class="section-gutter w-full mb-2">
+      <div class="text-secondary-purple font-semibold bg-[#E6E9F5]/50 mt-[2px] flex items-center text-body-md-18 mb-4 h-12 px-4 sm:text-body-lg-24 sm:h-14 sm:px-6 xl:text-heading-28 xl:h-16 xl:px-8
+    ">
+        <%= "Annotations for \"#{@file.title}\""  %>
+      </div>
+
+      <div class="flex flex-wrap gap-6">
+        <%= if Enum.empty?(@approved_descriptions) and Enum.empty?(@approved_subjects) do %>
+          <p class="text-gray-500 text-sm">No entries to display</p>
+        <% else %>
+          <%= for annotation <- @approved_descriptions do %>
+            <.description_annotation_card
+              annotation={annotation}
+              type="approved"
+              display_only?={true}
+            />
+          <% end %>
+          <%= for annotation <- @approved_subjects do %>
+            <.subject_annotation_card annotation={annotation} type="approved" display_only?={true} />
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/kosh_web/router.ex
+++ b/lib/kosh_web/router.ex
@@ -121,6 +121,7 @@ defmodule KoshWeb.Router do
       # live "/annotation/display/repositories/:repository_id/archival_objects/:object_id", DisplayLive, :show
 
       live "/annotation/all-annotations", PublicDisplayAllAnnotationsLive, :index
+      live "/annotation/file-annotations", PublicDisplayFileAnnotationsLive, :index
     end
 
     # get "/", PageController, :home


### PR DESCRIPTION
This PR implements the following changes:

- Added new details to the annotation cards: the user's email address who created the annotation, a hyperlink to the file, the file ID alongside the file's name, and the subject source for subject annotations. 
- Created a new route to view all annotations for the given file and linked that route to the file pages. 

CC: @dennyabrain 