### PR TITLE
fix: disable automatic entity expansion in parser while exporting XML

### DIFF
--- a/lib/kosh/ead/xml/saxy_update_ead_handler.ex
+++ b/lib/kosh/ead/xml/saxy_update_ead_handler.ex
@@ -424,7 +424,7 @@ defmodule Kosh.EAD.XML.SaxyUpdateEadHandler do
       initial_state = %__MODULE__{io: out_device, files: input}
 
       # Parse the string in SAX mode, streaming events to this module
-      {:ok, final_state} = Saxy.parse_stream(input_stream, __MODULE__, initial_state)
+      {:ok, final_state} = Saxy.parse_stream(input_stream, __MODULE__, initial_state, expand_entity: :never)
 
       # Retrieve the accumulated output
       {_input, output} = StringIO.contents(final_state.io)


### PR DESCRIPTION
This PR is linked to issue #49. As referenced in the issue, SAXY automatically expands character references: ex: `&amp;` to "&".  This option is now disabled to preserve the original formatting of the imported XML. 