### PR TITLE
fix: add new format for writing annotations in exported xml

### DIFF
--- a/lib/kosh/ead.ex
+++ b/lib/kosh/ead.ex
@@ -181,8 +181,7 @@ defmodule Kosh.EAD do
       accepted_description_annotations: [:file, :user],
       accepted_subjects_annotations: [:subjects, :file, :user]
     ])
-    |> Repo.get_by([uri: uri])
-
+    |> Repo.get_by(uri: uri)
   end
 
   @spec list_files() :: [struct()]
@@ -223,7 +222,10 @@ defmodule Kosh.EAD do
       files =
         File
         |> where([f], f.collection_id == ^collection_id)
-        |> preload([:accepted_description_annotations, accepted_subjects_annotations: [:subjects]])
+        |> preload([
+          :accepted_description_annotations,
+          accepted_subjects_annotations: [:subjects]
+        ])
         |> Repo.all()
 
       result =
@@ -231,6 +233,7 @@ defmodule Kosh.EAD do
         |> Enum.filter(fn f ->
           f.accepted_description_annotations != [] or f.accepted_subjects_annotations != []
         end)
+        # |> IO.inspect(label: "FILTERED FILES WITH ANNOTATIONS: ")
         |> Enum.map(fn f ->
           %{
             unitid: %{
@@ -240,13 +243,30 @@ defmodule Kosh.EAD do
             },
             description_annotations:
               Enum.map(f.accepted_description_annotations, fn da ->
-                %{id: da.id, description: da.description}
+                %{
+                  id: da.id,
+                  description: da.description,
+                  user_id: da.user_id,
+                  inserted_at: to_sql_ms(da.inserted_at)
+                }
               end),
             subjects_annotations:
               f.accepted_subjects_annotations
-              |> Enum.flat_map(fn sa -> sa.subjects || [] end)
+              |> Enum.flat_map(fn sa ->
+                (sa.subjects || [])
+                |> Enum.map(fn s ->
+                  Map.merge(s, %{anno_id: sa.id, user_id: sa.user_id, anno_inserted_at: sa.inserted_at})
+                end)
+              end)
               |> Enum.map(fn s ->
-                %{content: s.content, source: s.source, unitid: s.unitid}
+                %{
+                  content: s.content,
+                  source: s.source,
+                  unitid: s.unitid,
+                  anno_id: s.anno_id,
+                  user_id: s.user_id,
+                  inserted_at: to_sql_ms(s.anno_inserted_at)
+                }
               end)
           }
         end)
@@ -300,6 +320,16 @@ defmodule Kosh.EAD do
     |> where([s], ilike(s.content, ^"%#{name}%"))
     |> limit(10)
     |> Repo.all()
+  end
+
+
+  @fmt "%Y-%m-%d %H:%M:%S.%3f"
+
+  # Accept a DateTime (any timezone) — convert to UTC then format
+  def to_sql_ms(dt) do
+    dt
+    |> Timex.Timezone.convert("Etc/UTC")
+    |> Timex.format!(@fmt, :strftime)
   end
 
   @spec process_xml_file(String.t(), String.t()) :: {:ok, struct()} | {:error, String.t()}
@@ -383,7 +413,6 @@ defmodule Kosh.EAD do
   @spec process_node_for_db(map(), integer(), integer() | nil, integer() | nil) ::
           {:ok, struct()} | {:error, String.t()}
   defp process_node_for_db(%{type: :series} = node, collection_id, _series_id, _sub_series_id) do
-
     series_attrs =
       node
       |> Map.drop([:type, :children])
@@ -431,10 +460,10 @@ defmodule Kosh.EAD do
   end
 
   defp process_node_for_db(%{type: :file} = node, collection_id, series_id, sub_series_id) do
-
     IO.inspect(node, label: "FILE NODE: ")
     # Drop non-schema fields and add IDs
     file_uri = node.unitid.uri
+
     file_attrs =
       node
       |> Map.drop([:type])

--- a/lib/kosh/ead/xml/saxy_update_ead_handler.ex
+++ b/lib/kosh/ead/xml/saxy_update_ead_handler.ex
@@ -199,28 +199,25 @@ defmodule Kosh.EAD.XML.SaxyUpdateEadHandler do
   @impl true
   def handle_event(:end_element, name, %{current_file: current_file} = state)
       when name == "c" do
-    # check for scopecontent. Possible that there are new description annotations
-    # to be added but the scopecontent is not present. If it is the case,
-    # add new descriptions after creating scopecontent
 
-
-
-    # if state.in_scopecontent == false and not is_nil(current_file) do
     if not is_nil(current_file) do
       new_descs = get_in(state.current_file, [:description_annotations]) || []
 
       if(new_descs != []) do
-        write(state, "<scopecontent><head>annomilli-annotation</head>")
 
         Enum.each(new_descs, fn desc ->
+          write(state, ~s(<scopecontent id="annnomilli-id_#{desc.id}_user_id_#{desc.user_id}_timestamp_#{desc.inserted_at}">))
+          write(state, "<head>annomilli-annotation</head>")
           write(state, "<p>#{xml_escape(desc.description)}</p>")
+          write(state, "</scopecontent>")
         end)
 
-        write(state, "</scopecontent>")
       end
     end
 
-    # Same as above but for controlaccess.
+    # check for controlaccess. Possible that there are new subject annotations
+    # to be added but the controlaccess is not present. If it is the case,
+    # add new subjects after creating controlaccess
     if !state.in_controlaccess and not is_nil(current_file) do
       new_subs = state.current_file.subjects_annotations || []
 
@@ -253,23 +250,23 @@ defmodule Kosh.EAD.XML.SaxyUpdateEadHandler do
     {:ok, state}
   end
 
-  @impl true
-  def handle_event(:end_element, name, %{in_file: in_file, current_file: current_file} = state)
-      when name == "scopecontent" and in_file and not is_nil(current_file) do
-    new_descs =
-      (current_file.description_annotations || [])
-      |> Enum.map(fn annotation -> annotation.description end)
+  # @impl true
+  # def handle_event(:end_element, name, %{in_file: in_file, current_file: current_file} = state)
+  #     when name == "scopecontent" and in_file and not is_nil(current_file) do
+  #   new_descs =
+  #     (current_file.description_annotations || [])
+  #     |> Enum.map(fn annotation -> annotation.description end)
 
-    new_descs = remove_existing_descriptions(state.descriptions_stack, new_descs)
+  #   new_descs = remove_existing_descriptions(state.descriptions_stack, new_descs)
 
-    # Enum.each(new_descs, fn desc ->
-    #   write(state, "<p>#{xml_escape(desc)}</p>")
-    # end)
+  #   # Enum.each(new_descs, fn desc ->
+  #   #   write(state, "<p>#{xml_escape(desc)}</p>")
+  #   # end)
 
-    write(state, "</#{name}>")
-    # state = %{state | in_scopecontent: false}
-    {:ok, state}
-  end
+  #   write(state, "</#{name}>")
+  #   # state = %{state | in_scopecontent: false}
+  #   {:ok, state}
+  # end
 
   @impl true
   def handle_event(:end_element, name, %{in_file: in_file, current_file: current_file} = state)
@@ -349,10 +346,14 @@ defmodule Kosh.EAD.XML.SaxyUpdateEadHandler do
     source = Map.get(sub, :source)
     unitid = Map.get(sub, :unitid)
     content = Map.get(sub, :content)
+    anno_id = Map.get(sub, :anno_id)
+    user_id = Map.get(sub, :user_id)
+    inserted_at = Map.get(sub, :inserted_at)
 
     attrs =
       for {value, attr} <- [
-            {source, "source"},
+            # {source, "source"},
+            {"annnomilli-id_#{anno_id}_user_id_#{user_id}_timestamp_#{inserted_at}", "source"},
             {unitid, "id"}
           ],
           value not in [nil, ""] do


### PR DESCRIPTION
This PR implements a new format for writing annotations in the exported XML file as described in issue #52 