### PR TITLE
fix: long ead import timeout error

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -8,7 +8,8 @@ config :kosh, Kosh.Repo,
   database: "kosh_dev",
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,
-  pool_size: 10
+  pool_size: 10,
+  timeout: 120_000
 
 # For development, we disable any cache and enable
 # debugging and code reloading.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -30,6 +30,7 @@ if config_env() == :prod do
     hostname: System.get_env("DATABASE_HOSTNAME"),
     database: System.get_env("DATABASE_NAME"),
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
+    timeout: String.to_integer(System.get_env("DATABASE_TIMEOUT") || "120000"),
     socket_options: maybe_ipv6,
     stacktrace: true
 

--- a/lib/kosh/ead.ex
+++ b/lib/kosh/ead.ex
@@ -1083,7 +1083,7 @@ defmodule Kosh.EAD do
         end
 
       {:error, changeset} ->
-        {:error, "Failed to create file: #{inspect(changeset.errors)}"}
+        {:error, "Failed to create file: #{inspect(changeset.errors)}, File Attributes: #{inspect(file_attrs)}"}
     end
   end
 

--- a/lib/kosh_web/live/url_ead_upload_live.ex
+++ b/lib/kosh_web/live/url_ead_upload_live.ex
@@ -4,6 +4,7 @@ defmodule KoshWeb.UrlEadUploadLive do
   """
   use KoshWeb, :live_view
   alias Kosh.EAD
+  alias Phoenix.LiveView.AsyncResult
   import Ecto.Changeset
   alias KoshWeb.UploadHelpers
   require Logger
@@ -14,98 +15,21 @@ defmodule KoshWeb.UrlEadUploadLive do
     {:ok,
      assign(socket,
        form: to_form(changeset, as: "form"),
-       message: nil,
-       message_type: nil
+       import_result: nil
      )}
   end
 
   def handle_event("get-ead", %{"form" => form_params}, socket) do
-
-    changeset =
-      Ecto.Changeset.cast({%{}, %{endpoint: :string}}, form_params, [:endpoint])
-      |> validate_required([:endpoint])
-      |> validate_format(:endpoint, ~r/^https?:\/\//, message: "must be a valid URL")
+    changeset = endpoint_changeset(form_params)
 
     case changeset do
       %{valid?: true, changes: %{endpoint: endpoint}} ->
-        with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- HTTPoison.get(endpoint),
-             {:ok, %{file_name: file_name, temp_path: temp_path, processed_map: processed_map}} <-
-               EAD.process_and_get_fetched_ead_details(body),
-             dest_full <- Path.join([:code.priv_dir(:kosh), "static", "uploads", file_name]) do
-          if File.exists?(dest_full) do
-            {:noreply,
-             socket
-             |> assign(
-               form: to_form(changeset, as: "form"),
-               message: "File with the same name #{file_name} already exists",
-               message_type: "error"
-             )}
-          else
-            UploadHelpers.ensure_uploads_dir()
-
-            case EAD.import_fetched_ead_content(processed_map, temp_path, dest_full) do
-              {:ok, _collection} ->
-                changeset = Ecto.Changeset.cast({%{}, %{endpoint: :string}}, %{}, [:endpoint])
-
-                {:noreply,
-                 socket
-                 |> assign(
-                   message: "Successfully processed URL: #{endpoint}",
-                   message_type: "success",
-                   form: to_form(changeset, as: "form")
-                 )}
-
-              {:error, reason} ->
-                # IO.inspect(reason)
-                Logger.error("Error while processing EAD #{inspect(reason, pretty: true)}")
-
-                {:noreply,
-                 socket
-                 |> assign(
-                   form: to_form(changeset, as: "form"),
-                   message:
-                     "Error while processing EAD content: #{inspect(reason, pretty: true)}",
-                   message_type: "error"
-                 )}
-            end
-          end
-        else
-          {:error, %HTTPoison.Error{reason: reason}} ->
-            {:noreply,
-             socket
-             |> assign(
-               form: to_form(changeset, as: "form"),
-               message: "Failed to fetch URL: #{inspect(reason, pretty: true)}",
-               message_type: "error"
-             )}
-
-          {:ok, %HTTPoison.Response{status_code: status}} ->
-            {:noreply,
-             socket
-             |> assign(
-               form: to_form(changeset, as: "form"),
-               message: "Received non-200 status code: #{status}",
-               message_type: "error"
-             )}
-
-          {:error, reason} when is_binary(reason) ->
-            {:noreply,
-             socket
-             |> assign(
-               form: to_form(changeset, as: "form"),
-               message: "Error processing EAD: #{reason}",
-               message_type: "error"
-             )}
-
-          error ->
-            {:noreply,
-             socket
-             |> assign(
-               form: to_form(changeset, as: "form"),
-               message: "Unexpected error: #{inspect(error, pretty: true)}",
-               message_type: "error"
-             )}
-        end
+        {:noreply,
+         socket
+         |> assign(form: to_form(changeset, as: "form"))
+         |> assign_async(:import_result, fn ->
+           import_ead_from_endpoint(endpoint)
+         end, reset: true)}
 
       %{valid?: false} ->
         error_messages =
@@ -113,17 +37,82 @@ defmodule KoshWeb.UrlEadUploadLive do
           |> format_errors(fn {msg, _opts} -> msg end)
           |> Enum.map_join(", ", fn {_, [msg | _]} -> msg end)
 
-        IO.inspect(error_messages, label: "Form validation errors")
-
         {:noreply,
          socket
-         |> assign(
-           form: to_form(changeset, as: "form"),
-           message: error_messages,
-           message_type: "error"
-         )}
+         |> assign(form: to_form(changeset, as: "form"))
+         |> assign(import_result: AsyncResult.ok(error_result(error_messages)))}
     end
   end
+
+  defp endpoint_changeset(params) do
+    Ecto.Changeset.cast({%{}, %{endpoint: :string}}, params, [:endpoint])
+    |> validate_required([:endpoint])
+    |> validate_format(:endpoint, ~r/^https?:\/\//, message: "must be a valid URL")
+  end
+
+  defp import_ead_from_endpoint(endpoint) do
+    Logger.info("Starting fetch from endpoint: #{endpoint}")
+
+    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <-
+           HTTPoison.get(endpoint, [],
+             timeout: 120_000,
+             recv_timeout: 120_000,
+             connect_timeout: 120_000
+           ),
+         {:ok, %{file_name: file_name, temp_path: temp_path, processed_map: processed_map}} <-
+           EAD.process_and_get_fetched_ead_details(body) do
+      dest_full = Path.join([:code.priv_dir(:kosh), "static", "uploads", file_name])
+
+      if File.exists?(dest_full) do
+        {:ok, %{import_result: error_result("File with the same name #{file_name} already exists")}}
+      else
+        UploadHelpers.ensure_uploads_dir()
+
+        case EAD.import_fetched_ead_content(processed_map, temp_path, dest_full) do
+          {:ok, _collection} ->
+            {:ok, %{import_result: success_result("Successfully processed URL: #{endpoint}")}}
+
+          {:error, reason} ->
+            Logger.error("Error while processing EAD #{inspect(reason, pretty: true)}")
+
+            {:ok,
+             %{
+               import_result:
+                 error_result("Error while processing EAD content: #{inspect(reason, pretty: true)}")
+             }}
+        end
+      end
+    else
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        Logger.error("HTTPoison error fetching #{endpoint}: #{inspect(reason, pretty: true)}")
+        {:ok, %{import_result: error_result("Failed to fetch URL: #{inspect(reason, pretty: true)}")}}
+
+      {:ok, %HTTPoison.Response{status_code: status}} ->
+        {:ok, %{import_result: error_result("Received non-200 status code: #{status}")}}
+
+      {:error, reason} when is_binary(reason) ->
+        {:ok, %{import_result: error_result("Error processing EAD: #{reason}")}}
+
+      error ->
+        {:ok, %{import_result: error_result("Unexpected error: #{inspect(error, pretty: true)}")}}
+    end
+  rescue
+    error ->
+      Logger.error("Unexpected exception while processing EAD #{inspect(error, pretty: true)}")
+      {:ok, %{import_result: error_result("Unexpected error: #{inspect(error, pretty: true)}")}}
+  end
+
+  defp success_result(message), do: %{message: message, message_type: "success"}
+  defp error_result(message), do: %{message: message, message_type: "error"}
+
+  defp loading?(%AsyncResult{loading: loading}) when not is_nil(loading), do: true
+  defp loading?(_), do: false
+
+  defp status_classes("error"), do: "bg-red-100 text-red-800"
+  defp status_classes(_), do: "bg-green-100 text-green-800"
+
+  defp format_async_failure({:exit, reason}), do: inspect(reason, pretty: true)
+  defp format_async_failure(reason), do: inspect(reason, pretty: true)
 
   defp format_errors(changeset, msg_func) when is_function(msg_func, 1) do
     changeset
@@ -140,10 +129,22 @@ defmodule KoshWeb.UrlEadUploadLive do
             Fetch and Import EAD XML File from OAI Endpoint
           </h2>
 
-          <%= if @message do %>
-            <div class={"mb-4 p-3 rounded-md #{if @message_type == "error", do: "bg-red-100 text-red-800", else: "bg-green-100 text-green-800"}"}>
-              <%= @message %>
-            </div>
+          <%= if @import_result do %>
+            <.async_result :let={result} assign={@import_result}>
+              <:loading>
+                <div class="mb-4 p-3 rounded-md bg-blue-100 text-blue-800">
+                  Fetching and processing EAD. This can take a little while.
+                </div>
+              </:loading>
+              <:failed :let={failure}>
+                <div class="mb-4 p-3 rounded-md bg-red-100 text-red-800">
+                  Error while processing EAD content: <%= format_async_failure(failure) %>
+                </div>
+              </:failed>
+              <div class={"mb-4 p-3 rounded-md #{status_classes(result.message_type)}"}>
+                <%= result.message %>
+              </div>
+            </.async_result>
           <% end %>
 
           <.form for={@form} phx-submit="get-ead" class="flex flex-col w-full">
@@ -155,6 +156,7 @@ defmodule KoshWeb.UrlEadUploadLive do
                   placeholder="OAI Endpoint..."
                   class="w-full h-10 rounded-r-none !text-primary-purple placeholder:text-primary-purple/70 !text-body-md-18 border !border-primary-purple"
                   phx-debounce="300"
+                  disabled={loading?(@import_result)}
                 />
                 <%= if error = @form[:endpoint].errors do %>
                   <p class="mt-1 text-sm text-red-600">
@@ -164,10 +166,18 @@ defmodule KoshWeb.UrlEadUploadLive do
               </div>
               <button
                 type="submit"
-                class="btn-primary-purple text-body-md-18 font-semibold py-2 px-4 h-10 w-auto rounded-l-none mt-1 whitespace-nowrap"
+                class="btn-primary-purple text-body-md-18 font-semibold py-2 px-4 h-10 w-auto rounded-l-none mt-1 whitespace-nowrap disabled:opacity-75 disabled:hover:bg-primary-purple"
+                disabled={loading?(@import_result)}
                 phx-disable-with="Processing..."
               >
-                Search
+                <%= if loading?(@import_result) do %>
+                  <span class="inline-flex items-center gap-2">
+                    <span class="h-4 w-4 rounded-full border-2 border-white border-t-transparent animate-spin"></span>
+                    Processing...
+                  </span>
+                <% else %>
+                  Search
+                <% end %>
               </button>
             </div>
           </.form>


### PR DESCRIPTION
This PR fixes Issue #91 
The following changes have been implemented:
1. DB timeout is now specifically set to 2 minutes, so that processing longer EADs during a transaction does not close the DB connection. 
2. For Prod, a new variable `DATABASE_TIMEOUT` can be added to set the DB timeout; the default value is set to 2 minutes if no env variable is found.  
3. In the `url_ead_upload`, implement the `async_assign` to manage the result of the EAD import from URL. Otherwise, for longer EADs, even if EADs were being imported in the backend, Liveview kept timing out while waiting for the response, and then got refreshed. 
**URLs:**
assign_async: https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#assign_async/4
Info about the struct assign_async created to manage states: https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.AsyncResult.html
async_result component used to render info based on assign_async state: https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#async_result/1
Doc on Async operations (also mentions the async_result component): https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#module-async-operations 

4. Minor change:  In `process_node_for_db(%{type: :file}`, added log for files attributes as well. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading indicator and interactive feedback during EAD import operations, allowing users to see processing progress while fetching and importing content.

* **Bug Fixes**
  * Improved error handling with more detailed diagnostic information displayed when import operations encounter issues.

* **Performance**
  * Configured database operation timeout settings to ensure system responsiveness during long-running database queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->