### PR TITLE
Fix/import issues

### DIFF
--- a/lib/kosh/ead.ex
+++ b/lib/kosh/ead.ex
@@ -698,18 +698,27 @@ defmodule Kosh.EAD do
   end
 
   defp get_name_from_fetched_ead_content(ead_map) do
-    get_in(ead_map, [
-      "OAI-PMH",
-      "GetRecord",
-      "record",
-      "metadata",
-      "ead",
-      "eadheader",
-      "filedesc",
-      "titlestmt",
-      "titleproper",
-      "content"
-    ])
+    titleproper =
+      get_in(ead_map, [
+        "OAI-PMH",
+        "GetRecord",
+        "record",
+        "metadata",
+        "ead",
+        "eadheader",
+        "filedesc",
+        "titlestmt",
+        "titleproper"
+      ])
+
+    titleproper =
+      if is_list(titleproper) do
+        List.first(titleproper)
+      else
+        titleproper
+      end
+
+    get_in(titleproper, ["content"])
   end
 
   # Creates a temporary file with the given content and returns its path.
@@ -1083,7 +1092,8 @@ defmodule Kosh.EAD do
         end
 
       {:error, changeset} ->
-        {:error, "Failed to create file: #{inspect(changeset.errors)}, File Attributes: #{inspect(file_attrs)}"}
+        {:error,
+         "Failed to create file: #{inspect(changeset.errors)}, File Attributes: #{inspect(file_attrs)}"}
     end
   end
 

--- a/lib/kosh/ead.ex
+++ b/lib/kosh/ead.ex
@@ -718,7 +718,11 @@ defmodule Kosh.EAD do
         titleproper
       end
 
-    get_in(titleproper, ["content"])
+    case titleproper do
+      %{"content" => content} when is_binary(content) -> content
+      content when is_binary(content) -> content
+      _ -> nil
+    end
   end
 
   # Creates a temporary file with the given content and returns its path.

--- a/lib/kosh/ead/xml/saxmap.ex
+++ b/lib/kosh/ead/xml/saxmap.ex
@@ -70,12 +70,11 @@ defmodule Kosh.EAD.XML.Saxmap do
          collection_title when not is_nil(collection_title) <-
            get_in(collection_did, ["unittitle"]) do
       collection_scopecontent = get_in(archdesc, ["scopecontent"]) || %{}
-      collection_subjects = get_in(archdesc, ["controlaccess", "subject"]) || []
+      collection_subjects = (get_in(archdesc, ["controlaccess", "subject"]) || []) |> List.wrap()
       collection_unitdate = get_in(collection_did, ["unitdate"]) || %{}
 
       {collection_unitid, collection_unit_code} =
         extract_unitid(collection_did)
-
       collection = %{
         title: collection_title,
         unit_code: collection_unit_code,

--- a/lib/kosh/ead/xml/saxmap.ex
+++ b/lib/kosh/ead/xml/saxmap.ex
@@ -69,12 +69,13 @@ defmodule Kosh.EAD.XML.Saxmap do
          collection_did when not is_nil(collection_did) <- get_in(archdesc, ["did"]),
          collection_title when not is_nil(collection_title) <-
            get_in(collection_did, ["unittitle"]) do
-      collection_scopecontent = get_in(archdesc, ["scopecontent"]) || %{}
+      collection_scopecontent = get_collection_scopecontent(archdesc)
       collection_subjects = (get_in(archdesc, ["controlaccess", "subject"]) || []) |> List.wrap()
-      collection_unitdate = get_in(collection_did, ["unitdate"]) || %{}
+      collection_unitdate = extract_unitdate(collection_did)
 
       {collection_unitid, collection_unit_code} =
         extract_unitid(collection_did)
+
       collection = %{
         title: collection_title,
         unit_code: collection_unit_code,
@@ -90,6 +91,16 @@ defmodule Kosh.EAD.XML.Saxmap do
       {:ok, {collection, nested_structure}}
     else
       nil -> {:error, "Invalid EAD structure: missing required fields"}
+    end
+  end
+
+  defp get_collection_scopecontent(archdesc) do
+    scopecontent = get_in(archdesc, ["scopecontent"]) || %{}
+
+    if is_list(scopecontent) do
+      List.first(scopecontent)
+    else
+      scopecontent
     end
   end
 
@@ -133,7 +144,7 @@ defmodule Kosh.EAD.XML.Saxmap do
               node
               |> get_in(["scopecontent", "p"])
               |> List.wrap(),
-            unitdate: node["did"]["unitdate"] || %{},
+            unitdate: extract_unitdate(node["did"]),
             dao: node |> extract_dao(),
             subjects: node["controlaccess"]["subject"] |> List.wrap()
           }
@@ -173,7 +184,7 @@ defmodule Kosh.EAD.XML.Saxmap do
         %{
           xlink_title: title,
           xlink_type: type,
-          #Storing in DAOlocs as it is being used to render dao objects in the file display
+          # Storing in DAOlocs as it is being used to render dao objects in the file display
           daolocs:
             Enum.map(List.wrap(dao), fn loc ->
               %{
@@ -224,6 +235,16 @@ defmodule Kosh.EAD.XML.Saxmap do
 
       _ ->
         {%{}, nil}
+    end
+  end
+
+  defp extract_unitdate(did) do
+    unitdate = get_in(did, ["unitdate"]) || %{}
+
+    if is_list(unitdate) do
+      Enum.at(unitdate, 0)
+    else
+      unitdate
     end
   end
 end


### PR DESCRIPTION
This PR resolves import issues mentioned in #92, #93, #94

The following changes have been made, mentioning them together without specifically mentioning the related EAD:
- Collection_subjects are now wrapped in the list in the process of creating the processed_map. Everywhere where the subjects are being added to the collection or files, they are being treated as a list. As one EAD had only one subject for a collection, it was being processed as a map rather than a list, hence the error while importing. 
- Collection_scopecontent also has a similar case. As discussed in issue #94, scopecontent is not relevant for collections, but as we have already added them in the schema, in case there is a list of scopecontent, we are now storing the first one from the list.  
- Some EADs have multiple `unitdate` tags for files, but we are only storing one unitdate map per file. So, as discussed in issue #92, in case there are multiple unitdate tags, we are now keeping the first one for files and collections. 
- While uploading EAD from URL, we are extracting the title for naming the file from the `titleproper` tag nested deeply inside the `OAI-PMH` tag. Some EADs have 2 such tags, and therefore, there was an error while parsing this tag. As discussed in issue #93, we are now using the first titleproper tag (in case there are multiple).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction and normalization of metadata from archival records
  * Fixed handling of multi-valued fields in archival data processing to ensure consistent data structure formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->