### PR TITLE
encode annomilli-id.... to authfilenumber attribute instead of source; revert source back to mlk/lcsh

### DIFF
--- a/lib/kosh/ead/xml/saxy_update_ead_handler.ex
+++ b/lib/kosh/ead/xml/saxy_update_ead_handler.ex
@@ -402,8 +402,9 @@ defmodule Kosh.EAD.XML.SaxyUpdateEadHandler do
 
     attrs =
       for {value, attr} <- [
-            # {source, "source"},
-            {"annnomilli-id_#{anno_id}_user_id_#{user_id}_timestamp_#{inserted_at}", "source"},
+            {source, "source"},
+            # {"annomilli-id_#{anno_id}_user_id_#{user_id}_timestamp_#{inserted_at}", "source"},
+            {"annomilli-id_#{anno_id}_user_id_#{user_id}_timestamp_#{inserted_at}", "authfilenumber"},
             {unitid, "id"}
           ],
           value not in [nil, ""] do


### PR DESCRIPTION
forsubject annotations, encoding annomilli-id to the authfilenumber attribute makes more sense than using the source attribute
see https://eadiva.com/2/subject/

will this break anything during ingest of subjects anotations?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected attribute assignment in EAD subject metadata generation, ensuring annotation identifiers are now properly mapped to the correct field names while maintaining source references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->