### PR TITLE
feat: add namespace in file display url, update search with namespace

### DIFF
--- a/lib/kosh/search.ex
+++ b/lib/kosh/search.ex
@@ -23,28 +23,29 @@ defmodule Kosh.Search do
     # Use a helper to build the base query with all joins and where
     base_query = build_search_base_query(pattern)
 
-    # Step 1: Get matching file URIs (with distinct, pagination)
-    file_uris_query =
+    # Step 1: Get matching file keys (archival_space + uri) with distinct, pagination
+    file_keys_query =
       base_query
-      |> select([f], f.uri)
-      |> distinct([f], f.uri)
+      |> select([f], %{archival_space: f.archival_space, uri: f.uri})
+      |> distinct([f], [f.archival_space, f.uri])
       |> limit(^page_size)
       |> offset(^offset)
 
-    file_uris = Repo.all(file_uris_query)
-
-    # Step 2: Get total count (distinct uris)
+    # Step 2: Get total count (distinct file keys)
     total_count_query =
       base_query
-      |> select([f], f.uri)
-      |> distinct([f], f.uri)
+      |> select([f], %{archival_space: f.archival_space, uri: f.uri})
+      |> distinct([f], [f.archival_space, f.uri])
+      |> subquery()
 
     total_count = Repo.aggregate(total_count_query, :count, :uri)
 
-    # Step 3: Fetch files by URI, with all associations preloaded
+    # Step 3: Fetch files by file keys, with all associations preloaded
     files_query =
-      File
-      |> where([f], f.uri in ^file_uris)
+      from(f in File,
+        join: k in subquery(file_keys_query),
+        on: f.archival_space == k.archival_space and f.uri == k.uri
+      )
       |> preload([
         :collection,
         :series,
@@ -58,7 +59,7 @@ defmodule Kosh.Search do
 
     results =
       Repo.all(files_query)
-      |> Enum.uniq_by(& &1.uri)
+      |> Enum.uniq_by(&{&1.archival_space, &1.uri})
       |> Enum.map(&format_file(&1, q))
 
     %{results: results, total_count: total_count}
@@ -87,6 +88,7 @@ defmodule Kosh.Search do
       # file's direct subjects
       # subjects of each annotation
       ilike(f.title, ^pattern) or
+        ilike(f.archival_space, ^pattern) or
         ilike(f.uri, ^pattern) or
         fragment("array_to_string(?, ' ') ILIKE ?", f.description, ^pattern) or
         fragment("?->>'id' ILIKE ?", f.unitid, ^pattern) or
@@ -125,6 +127,7 @@ defmodule Kosh.Search do
       series_name: file.series && file.series.title,
       sub_series_name: file.sub_series && file.sub_series.title,
       description: Enum.join(file.description || [], " "),
+      archival_space: file.archival_space,
       uri: file.uri,
       unitid: file.unitid && file.unitid.id,
       dao_links:

--- a/lib/kosh/search.ex
+++ b/lib/kosh/search.ex
@@ -28,6 +28,7 @@ defmodule Kosh.Search do
       base_query
       |> select([f], %{archival_space: f.archival_space, uri: f.uri})
       |> distinct([f], [f.archival_space, f.uri])
+      |> order_by([f], asc: f.archival_space, asc: f.uri)
       |> limit(^page_size)
       |> offset(^offset)
 
@@ -46,6 +47,7 @@ defmodule Kosh.Search do
         join: k in subquery(file_keys_query),
         on: f.archival_space == k.archival_space and f.uri == k.uri
       )
+      |> order_by([_f, k], asc: k.archival_space, asc: k.uri)
       |> preload([
         :collection,
         :series,

--- a/lib/kosh_web/live/display_live.ex
+++ b/lib/kosh_web/live/display_live.ex
@@ -5,9 +5,12 @@ defmodule KoshWeb.DisplayLive do
 
   @impl Phoenix.LiveView
 
-  def mount(%{"uri" => uri}, _session, socket) do
+  def mount(%{"archival_space" => archival_space, "uri" => uri}, _session, socket) do
     # IO.inspect(socket, label: "id")
-    case EAD.get_file_from_uri(URI.decode(uri)) do
+    case EAD.get_file_from_archival_space_and_uri(
+           URI.decode(archival_space),
+           URI.decode(uri)
+         ) do
       nil ->
         {:ok,
          socket
@@ -42,6 +45,13 @@ defmodule KoshWeb.DisplayLive do
         {:ok,
          assign(socket, file: file, file_emotions: file_emotions, manifest_url: manifest_url)}
     end
+  end
+
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> put_flash(:error, "Invalid file URL. Missing archival_space or uri.")
+     |> redirect(to: ~p"/")}
   end
 
   defp fetch_item_uuid(handle_url) do

--- a/lib/kosh_web/live/search_live.ex
+++ b/lib/kosh_web/live/search_live.ex
@@ -70,8 +70,6 @@ defmodule KoshWeb.SearchLive do
         search_data
       end
 
-      IO.inspect(search_data.results, label: "RESULTS: ")
-
     {:noreply,
      assign(socket,
        results: search_data.results,

--- a/lib/kosh_web/live/search_live.ex
+++ b/lib/kosh_web/live/search_live.ex
@@ -70,6 +70,8 @@ defmodule KoshWeb.SearchLive do
         search_data
       end
 
+      IO.inspect(search_data.results, label: "RESULTS: ")
+
     {:noreply,
      assign(socket,
        results: search_data.results,
@@ -133,7 +135,7 @@ defmodule KoshWeb.SearchLive do
                 <div class="bg-white rounded-lg shadow-milli-1 border border-secondary-pale-grey p-6">
                   <div class="flex flex-col gap-2">
                     <%= if result.file_name do %>
-                      <.link navigate={~p"/annotation/display?uri=#{result.uri}"}>
+                      <.link navigate={~p"/annotation/display?archival_space=#{result.archival_space}&uri=#{result.uri}"}>
                         <span class="text-primary-purple font-bold text-xl hover:underline">
                           <%= Phoenix.HTML.raw(highlight(result.file_name, @query)) %>
                         </span>
@@ -176,6 +178,14 @@ defmodule KoshWeb.SearchLive do
                         <span class="font-bold text-primary-purple">URI:</span>
                         <span class="text-secondary-purple">
                           <%= Phoenix.HTML.raw(highlight(result.uri, @query)) %>
+                        </span>
+                      </div>
+                    <% end %>
+                    <%= if result.archival_space do %>
+                      <div>
+                        <span class="font-bold text-primary-purple">Archival Space:</span>
+                        <span class="text-secondary-purple">
+                          <%= Phoenix.HTML.raw(highlight(result.archival_space, @query)) %>
                         </span>
                       </div>
                     <% end %>


### PR DESCRIPTION
Related to #100 
- Added the archival_space attribute in the file display page. Ex: `http://localhost:4000/annotation/display?archival_space=archives.ncbs.res.in&uri=%2Frepositories%2F2%2Farchival_objects%2F26581`

Changes in Search:
- Updated search to treat file identity as (archival_space, uri) instead of uri alone, and updated search result links to include archival_space.
- This is because uri is no longer globally unique across archival spaces. URI-only search identity could merge/collide results from different spaces and generate ambiguous display links.
- Files can now be searched by the archival_space names as well. 

In search.ex:

- Distinct/pagination keys changed from uri to %{archival_space, uri}.
- Total count now computed from distinct composite keys.
- File fetch changed from where `f.uri in ^file_uris` to join on paginated key subquery: `f.archival_space == k.archival_space and f.uri == k.uri`
- De-duplication changed from Enum.uniq_by(& &1.uri) to Enum.uniq_by(&{&1.archival_space, &1.uri}).
- Search result map now includes archival_space.
- match_any now supports searching f.archival_space.
---
CC: @dakuojas, @dennyabrain 
