### PR TITLE
chore: add featured agents annotations, fix annotation form responsiveness

### DIFF
--- a/lib/kosh_web/components/annotation_section/annotation_section_wrapper.ex
+++ b/lib/kosh_web/components/annotation_section/annotation_section_wrapper.ex
@@ -43,10 +43,16 @@ defmodule KoshWeb.Components.AnnotationSection.AnnotationSectionWrapper do
       |> Enum.sort_by(& &1.inserted_at, :desc)
       |> Enum.take(3)
 
+    latest_accepted_agent_annotations =
+      file.accepted_agent_annotations
+      |> Enum.sort_by(& &1.inserted_at, :desc)
+      |> Enum.take(3)
+
     socket =
       assign(socket,
         latest_accepted_description_annotations: latest_accepted_description_annotations,
-        latest_accepted_subjects_annotations: latest_accepted_subjects_annotations
+        latest_accepted_subjects_annotations: latest_accepted_subjects_annotations,
+        latest_accepted_agent_annotations: latest_accepted_agent_annotations
       )
 
     # IO.inspect(socket, label: "Socket inside wrapper in update: ")

--- a/lib/kosh_web/components/annotation_section/annotation_section_wrapper.html.heex
+++ b/lib/kosh_web/components/annotation_section/annotation_section_wrapper.html.heex
@@ -5,8 +5,8 @@
   <p class="text-[#E9FFB1] text-body-lg-24 sm:text-heading-28 xl:text-display-40 font-bold mb-9">
     Discover what others have to say about these collections.
   </p>
-  <div class="py-10 sm:py-14 xl:py-20 bg-white flex flex-col lg:flex-row w-[90%] sm:w-[85%] xl:w-[80%] mx-auto rounded-lg space-y-10 lg:space-y-0 lg:space-x-10">
-    <div class="w-full lg:w-1/4 px-4 2xl:px-8">
+  <div class=" px-2 md:px-4 lg:px-6 2xl:px-8 py-10 sm:py-14 xl:py-20 bg-white flex flex-col lg:flex-row justify-center w-[90%] sm:w-[85%] xl:w-[80%] mx-auto rounded-lg space-y-10 lg:space-y-0 lg:space-x-10">
+    <div class="w-full lg:w-1/4 2xl:w-[15%] flex flex-col shrink-0">
       <button
         phx-click="show_featured"
         phx-target={@myself}
@@ -121,6 +121,7 @@
           current_user={@current_user}
           featured_description_annotations={@latest_accepted_description_annotations}
           featured_subjects_annotations={@latest_accepted_subjects_annotations}
+          featured_agent_annotations={@latest_accepted_agent_annotations}
         />
       <% 1-> %>
         <.live_component

--- a/lib/kosh_web/components/annotation_section/featured_annotations.ex
+++ b/lib/kosh_web/components/annotation_section/featured_annotations.ex
@@ -1,11 +1,8 @@
 defmodule KoshWeb.Components.AnnotationSection.FeaturedAnnotations do
   use Phoenix.LiveComponent
-  import KoshWeb.CoreComponents
-  alias Kosh.EAD
-  alias Kosh.Annotations
-  import Phoenix.LiveView
   import KoshWeb.Components.DescriptionAnnotationCard
   import KoshWeb.Components.SubjectAnnotationCard
+  import KoshWeb.Components.AgentAnnotationCard
 
   def mount(socket) do
     {:ok, socket}

--- a/lib/kosh_web/components/annotation_section/featured_annotations.html.heex
+++ b/lib/kosh_web/components/annotation_section/featured_annotations.html.heex
@@ -1,33 +1,60 @@
-<div class="flex space-x-3 justify-center">
-  <%= if Enum.empty?(@featured_description_annotations) and Enum.empty?(@featured_subjects_annotations) do %>
+<div class="flex flex-col 2xl:flex-row space-x-3 justify-center">
+  <%= if Enum.empty?(@featured_description_annotations) and Enum.empty?(@featured_subjects_annotations) and Enum.empty?(@featured_agent_annotations) do %>
     <div>
       <p class="text-secondary-purple font-bold text-body-md-18">Featured Annotations</p>
       <p class="text-secondary-grey my-3 mx-1 text-sm">No featured annotations to display.</p>
     </div>
   <% else %>
-    <div class="flex flex-col gap-3 flex-1">
+    <div class="flex flex-col  gap-3 flex-1 lg:mt-6 2xl:mt-0">
       <p class="text-secondary-purple font-bold 2xl:text-body-md-18">Descriptions</p>
       <%= if Enum.empty?(@featured_description_annotations) do %>
         <p class="text-secondary-grey text-sm">No featured annotations to display.</p>
       <% else %>
+          <div class="flex flex-wrap 2xl:flex-col gap-3">
         <%= for annotation <- @featured_description_annotations do %>
-          <.description_annotation_card
-            annotation={annotation}
-            type="approved"
-            display_only?={true}
-            is_featured?={true}
-          />
+            <.description_annotation_card
+              annotation={annotation}
+              type="approved"
+              display_only?={true}
+              is_featured?={true}
+            />
         <% end %>
+          </div>
       <% end %>
     </div>
-    <div class="flex flex-col gap-3 flex-1">
+   <div class="flex flex-col gap-3 flex-1 mt-4 lg:mt-6 2xl:mt-0">
       <p class="text-secondary-purple font-bold 2xl:text-body-md-18">Subjects</p>
       <%= if Enum.empty?(@featured_subjects_annotations) do %>
         <p class="text-secondary-grey text-sm">No featured annotations to display.</p>
       <% else %>
+          <div class="flex flex-wrap 2xl:flex-col gap-3">
         <%= for annotation <- @featured_subjects_annotations do %>
-          <.subject_annotation_card annotation={annotation} type="approved" display_only?={true} is_featured?={true} />
+            <.subject_annotation_card
+              annotation={annotation}
+              type="approved"
+              display_only?={true}
+              is_featured?={true}
+            />
         <% end %>
+          </div>
+      <% end %>
+    </div>
+
+    <div class="flex flex-col  gap-3 flex-1 lg:mt-6 2xl:mt-0">
+      <p class="text-secondary-purple font-bold 2xl:text-body-md-18">Agents</p>
+      <%= if Enum.empty?(@featured_agent_annotations) do %>
+        <p class="text-secondary-grey text-sm">No featured annotations to display.</p>
+      <% else %>
+          <div class="flex flex-wrap 2xl:flex-col gap-3">
+        <%= for annotation <- @featured_agent_annotations do %>
+            <.agent_annotation_card
+              annotation={annotation}
+              type="approved"
+              display_only?={true}
+              is_featured?={true}
+            />
+        <% end %>
+          </div>
       <% end %>
     </div>
   <% end %>

--- a/lib/kosh_web/live/admin_routes_display_live.ex
+++ b/lib/kosh_web/live/admin_routes_display_live.ex
@@ -49,6 +49,13 @@ defmodule KoshWeb.AdminRoutesDisplayLive do
           <span>Export EAD XML Collections with updated annotations</span>
           <img src="/images/redirect-color-primary.svg" alt="logo">
         </.link>
+        <.link
+          navigate={~p"/admin/export-subjects"}
+          class="flex items-center text-secondary-purple font-semibold hover:underline"
+        >
+          <span>Export Milli Local Knowledge Subjects</span>
+          <img src="/images/redirect-color-primary.svg" alt="logo">
+        </.link>
       </div>
 
       <div class="mt-8">

--- a/lib/kosh_web/live/display_index_live.ex
+++ b/lib/kosh_web/live/display_index_live.ex
@@ -11,7 +11,7 @@ defmodule KoshWeb.DisplayIndexLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <div class="section-gutter max-h-screen">
+    <div class="section-gutter w-full">
       <div class="w-full max-w-6xl mx-auto p-6">
         <div class="bg-white rounded-lg shadow-md ">
           <div class="bg-primary-purple p-6 flex justify-between items-center">
@@ -38,11 +38,11 @@ defmodule KoshWeb.DisplayIndexLive do
                 </.link> --%>
               </div>
             <% else %>
-              <div class="max-h-[70vh] 2xl:max-h-[50%] overflow-y-auto overflow-x-auto">
-                <table class="min-w-full divide-y divide-gray-200">
+              <div class="max-h-[70vh] 2xl:max-h-[60vh] overflow-y-auto overflow-x-auto">
+                <table class="w-full  divide-y divide-gray-200">
                   <thead>
                     <tr>
-                      <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th class="w-[30%] 2xl:w-[40%] px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                         Title
                       </th>
                       <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -60,7 +60,7 @@ defmodule KoshWeb.DisplayIndexLive do
                   <tbody class="bg-white divide-y divide-gray-200">
                     <%= for file <- @files do %>
                       <tr class="hover:bg-gray-50">
-                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                        <td class="px-6 py-4 text-sm font-medium text-gray-900 whitespace-normal break-words">
                           <%= file.title %>
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">


### PR DESCRIPTION
This is a UI fix PR:
- Adds Agents annotations in the Featured annotations section. 
- Improves the layout on small screens: 
  - for 2xl screens (ex: 27 inch monitor), the layout is the same. 
  - for small laptop screens (ex: 14 inch screen), the featured annotations are being rendered section-wise, one section below another.
  - For Phones, featured annotations are appearing all in one column. 
- Adds the URL to the `/admin/export-subjects` in the Admin index page. The Liveview and route already existed, but the URL was not present on the Admin index page. This fixes issue #83.
- Fixes the File Display table page layout and Table layout. It is now appearing normal in the large monitor screens as well. Removed the horizontal scroll for screens larger than phones.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Featured agent annotations now display in a dedicated "Agents" section alongside descriptions and subjects
  * Added new admin export option for Local Knowledge Subjects

* **Style**
  * Improved responsive layout design for annotation display sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->